### PR TITLE
Clean lib folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ activate*
 deactivate*
 conanbuild*
 test_package/build
+*~
+*.swp

--- a/conanfile.py
+++ b/conanfile.py
@@ -80,8 +80,7 @@ class ZlibConan(ConanFile):
                 self.copy(pattern="*zlib.lib", dst="lib", src="_build", keep_path=False)
                 self.copy(pattern="*zlib.dll.a", dst="lib", src="_build", keep_path=False)
             else:
-                self.copy(pattern="*zlibstaticd.*", dst="lib", src="_build", keep_path=False)
-                self.copy(pattern="*zlibstatic.*", dst="lib", src="_build", keep_path=False)
+                self.copy(pattern="zlibstatic*.lib", dst="lib", src="_build/lib")
         else:
             if self.options.shared:
                 if self.settings.os == "Macos":

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,9 +16,9 @@ class ZlibConan(ConanFile):
     url="http://github.com/lasote/conan-zlib"
     license="http://www.zlib.net/zlib_license.html"
     description="A Massively Spiffy Yet Delicately Unobtrusive Compression Library (Also Free, Not to Mention Unencumbered by Patents)"
-    
+
     def config(self):
-        del self.settings.compiler.libcxx 
+        del self.settings.compiler.libcxx
 
     def source(self):
         zip_name = "zlib-%s.tar.gz" % self.version
@@ -38,16 +38,16 @@ class ZlibConan(ConanFile):
             if self.settings.arch == "x86" or self.settings.arch == "x86_64":
                 env_line = env_line.replace('CFLAGS="', 'CFLAGS="-mstackrealign ')
             self.output.warn(env_line)
-                        
+
             if self.settings.os == "Macos":
                 old_str = '-install_name $libdir/$SHAREDLIBM'
                 new_str = '-install_name $SHAREDLIBM'
                 replace_in_file("./%s/configure" % self.ZIP_FOLDER_NAME, old_str, new_str)
-                     
+
             self.run("cd %s && %s ./configure" % (self.ZIP_FOLDER_NAME, env_line))
             #self.run("cd %s && %s make check" % (self.ZIP_FOLDER_NAME, env.command_line_env))
             self.run("cd %s && %s make" % (self.ZIP_FOLDER_NAME, env_line))
-         
+
         else:
             cmake = CMake(self.settings)
             if self.settings.os == "Windows":
@@ -66,7 +66,7 @@ class ZlibConan(ConanFile):
         """
         # Copy findZLIB.cmake to package
         self.copy("FindZLIB.cmake", ".", ".")
-        
+
         # Copying zlib.h, zutil.h, zconf.h
         self.copy("*.h", "include", "%s" % (self.ZIP_FOLDER_NAME), keep_path=False)
         self.copy("*.h", "include", "%s" % ("_build"), keep_path=False)


### PR DESCRIPTION
Hi!

Recently I have been playing with some packages depending on zlib and with one of them I have some problems when finding the zlib library. Although the CMake configuration for that project seems to be not correct, I noticed that the zlib recipe is exporting lot of stuff that might not be needed for the package. This is the content of zlib/package/lib on Windows/Static right now:

```
total 539K
-rw-r--r-- 1 Luis 197121 2.3K Jan  3 13:22 adler32.obj
-rw-r--r-- 1 Luis 197121  27K Jan  3 13:22 cl.command.1.tlog
-rw-r--r-- 1 Luis 197121  43K Jan  3 13:22 CL.read.1.tlog
-rw-r--r-- 1 Luis 197121 8.2K Jan  3 13:22 CL.write.1.tlog
-rw-r--r-- 1 Luis 197121 1.9K Jan  3 13:22 compress.obj
-rw-r--r-- 1 Luis 197121  15K Jan  3 13:22 crc32.obj
-rw-r--r-- 1 Luis 197121 1.5K Jan  3 13:22 custombuild.command.1.tlog
-rw-r--r-- 1 Luis 197121 2.3K Jan  3 13:22 custombuild.read.1.tlog
-rw-r--r-- 1 Luis 197121  556 Jan  3 13:22 custombuild.write.1.tlog
-rw-r--r-- 1 Luis 197121  37K Jan  3 13:22 deflate.obj
-rw-r--r-- 1 Luis 197121  692 Jan  3 13:22 gzclose.obj
-rw-r--r-- 1 Luis 197121  13K Jan  3 13:22 gzlib.obj
-rw-r--r-- 1 Luis 197121  14K Jan  3 13:22 gzread.obj
-rw-r--r-- 1 Luis 197121  13K Jan  3 13:22 gzwrite.obj
-rw-r--r-- 1 Luis 197121  13K Jan  3 13:22 infback.obj
-rw-r--r-- 1 Luis 197121 2.7K Jan  3 13:22 inffast.obj
-rw-r--r-- 1 Luis 197121  29K Jan  3 13:22 inflate.obj
-rw-r--r-- 1 Luis 197121 3.9K Jan  3 13:22 inftrees.obj
-rw-r--r-- 1 Luis 197121 5.9K Jan  3 13:22 lib.command.1.tlog
-rw-r--r-- 1 Luis 197121 9.3K Jan  3 13:22 Lib-link.read.1.tlog
-rw-r--r-- 1 Luis 197121 4.8K Jan  3 13:22 Lib-link.write.1.tlog
-rw-r--r-- 1 Luis 197121  20K Jan  3 13:22 trees.obj
-rw-r--r-- 1 Luis 197121 3.2K Jan  3 13:22 uncompr.obj
-rw-r--r-- 1 Luis 197121  253 Jan  3 13:22 zlibstatic.lastbuildstate
-rw-r--r-- 1 Luis 197121 175K Jan  3 13:22 zlibstatic.lib
-rw-r--r-- 1 Luis 197121  33K Jan  3 13:22 zlibstatic.vcxproj
-rw-r--r-- 1 Luis 197121 5.9K Jan  3 13:22 zlibstatic.vcxproj.filters
-rw-r--r-- 1 Luis 197121 2.8K Jan  3 13:22 zutil.obj
```

I think that the only needed file here is the .lib file. 

Note: I am pointing this PR to the release/1.2.9 branch. Let me know if I have to point to other target branch. 