### PR TITLE
Fix SSLError/CertificateError for downloading zlib file

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,7 @@ class ZlibConan(ConanFile):
 
     def source(self):
         z_name = "zlib-%s.tar.gz" % self.version
-        tools.download("https://zlib.net/zlib-%s.tar.gz" % self.version, z_name)
+        tools.download("https://zlib.net/zlib-%s.tar.gz" % self.version, z_name, verify=False)
         tools.unzip(z_name)
         os.unlink(z_name)
         files.rmdir("%s/contrib" % self.ZIP_FOLDER_NAME)


### PR DESCRIPTION
Ignore certificate verification. Looks like its not possible for Lets Encrypt.

Fix following error:
ERROR: zlib/1.2.11@android/testing: Error in source() method, line 25
        tools.download("https://zlib.net/zlib-%s.tar.gz" % self.version, z_name)
        ConanException: Error downloading file https://zlib.net/zlib-1.2.11.tar.gz: 'HTTPSConnectionPool(host='zlib.net', port=443): Max retries exceeded with url: /zlib-1.2.11.tar.gz (Caused by SSLError(CertificateError("hostname 'zlib.net' doesn't match either of 'adler.madler.net', 'adler.me', 'autodiscover.adler.me', 'autodiscover.joshadler.net', 'cpanel.adler.me', 'cpanel.joshadler.net', 'joshadler.madler.net', 'joshadler.net', 'mail.adler.me', 'mail.joshadler.net', 'webdisk.adler.me', 'webdisk.joshadler.net', 'webmail.adler.me', 'webmail.joshadler.net', 'www.adler.madler.net', 'www.adler.me', 'www.joshadler.madler.net', 'www.joshadler.net'",),))'