### PR TITLE
Keep it build script simple and clean

### DIFF
--- a/CMakeLists.patch
+++ b/CMakeLists.patch
@@ -1,0 +1,81 @@
+--- CMakeLists.txt.orig	2018-04-06 22:33:28.000000000 +0200
++++ CMakeLists.txt	2018-04-06 23:21:28.000000000 +0200
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4.4)
++cmake_minimum_required(VERSION 3.1.2)
+ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
+ 
+ project(zlib C)
+@@ -123,7 +123,7 @@
+     zutil.c
+ )
+ 
+-if(NOT MINGW)
++if(NOT MINGW AND NOT MSYS)
+     set(ZLIB_DLL_SRCS
+         win32/zlib1.rc # If present will override custom build rule below.
+     )
+@@ -167,7 +167,7 @@
+ string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
+     "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
+ 
+-if(MINGW)
++if(BUILD_SHARED_LIBS AND MINGW)
+     # This gets us DLL resource information when compiling on MinGW.
+     if(NOT CMAKE_RC_COMPILER)
+         set(CMAKE_RC_COMPILER windres.exe)
+@@ -181,14 +181,17 @@
+                             -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+                             -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
+     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
+-endif(MINGW)
++endif()
+ 
+-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
+-set_target_properties(zlib PROPERTIES SOVERSION 1)
++if(BUILD_SHARED_LIBS)
++    add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
++    set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
++    set_target_properties(zlib PROPERTIES SOVERSION 1)
++else()
++    add_library(zlib STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
++endif()
+ 
+-if(NOT CYGWIN)
++if(BUILD_SHARED_LIBS AND NOT CYGWIN)
+     # This property causes shared libraries on Linux to have the full version
+     # encoded into their final filename.  We disable this on Cygwin because
+     # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
+@@ -201,17 +204,17 @@
+ 
+ if(UNIX)
+     # On unix-like platforms the library is almost always called libz
+-   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
+-   if(NOT APPLE)
+-     set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
+-   endif()
++    set_target_properties(zlib PROPERTIES OUTPUT_NAME z)
++    if(BUILD_SHARED_LIBS AND NOT APPLE)
++        set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
++    endif()
+ elseif(BUILD_SHARED_LIBS AND WIN32)
+     # Creates zlib1.dll when building shared library version
+     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+ endif()
+ 
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
+-    install(TARGETS zlib zlibstatic
++    install(TARGETS zlib
+         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+         LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+@@ -232,6 +235,7 @@
+ 
+ add_executable(example test/example.c)
+ target_link_libraries(example zlib)
++
+ add_test(example example)
+ 
+ add_executable(minigzip test/minigzip.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ conan_basic_setup(TARGETS)
 option(BUILD_SHARED_LIBS "Build shared libraries(DLLs)." OFF)
 
 # disable unwanted debug postfix 'd'
-set(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Not useful with conan, should be empty!" FORCE)
+### set(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Not useful with conan, should be empty!" FORCE)
 
 # The zlib CMakeFile.txt is a nightmare! CK
 set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,8 @@ option(BUILD_SHARED_LIBS "Build shared libraries(DLLs)." OFF)
 # disable unwanted debug postfix 'd'
 set(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Not useful with conan, should be empty!" FORCE)
 
+# The zlib CMakeFile.txt is a nightmare! CK
+set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
+
 include_directories(${CMAKE_SOURCE_DIR}/zlib-1.2.11)
 add_subdirectory("./zlib-1.2.11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,11 @@ conan_basic_setup(TARGETS)
 
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to
 # make it prominent in the GUI.
+# NOTE: unfortunately this is not respected by the zlib CMakeLists.txt file yet! CK
 option(BUILD_SHARED_LIBS "Build shared libraries(DLLs)." OFF)
 
-# set debug postfix a la gtest
-### set(CMAKE_DEBUG_POSTFIX "d")
+# disable unwanted debug postfix 'd'
+set(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Not useful with conan, should be empty!" FORCE)
 
 include_directories(${CMAKE_SOURCE_DIR}/zlib-1.2.11)
 add_subdirectory("./zlib-1.2.11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,8 @@ option(BUILD_SHARED_LIBS "Build shared libraries(DLLs)." OFF)
 # The zlib CMakeFile.txt is a nightmare! CK
 set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 
+# on project level needed! CK
+enable_testing()
+
 include_directories(${CMAKE_SOURCE_DIR}/zlib-1.2.11)
 add_subdirectory("./zlib-1.2.11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
-PROJECT(conanzlib)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.2)
+project(conanzlib C)
+
 include(conanbuildinfo.cmake)
-CONAN_BASIC_SETUP()
+conan_basic_setup(TARGETS)
+
+# BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to
+# make it prominent in the GUI.
+option(BUILD_SHARED_LIBS "Build shared libraries(DLLs)." OFF)
+
+# set debug postfix a la gtest
+### set(CMAKE_DEBUG_POSTFIX "d")
+
 include_directories(${CMAKE_SOURCE_DIR}/zlib-1.2.11)
 add_subdirectory("./zlib-1.2.11")

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class ZlibConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False]}
     default_options = "shared=False"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "CMakeLists.patch"]
     url = "http://github.com/lasote/conan-zlib"
     license = "http://www.zlib.net/zlib_license.html"
     description = "A Massively Spiffy Yet Delicately Unobtrusive Compression Library " \
@@ -37,12 +37,9 @@ class ZlibConan(ConanFile):
                                   '#if defined(_WIN32) && !defined(__CYGWIN__)')
             self.output.warn("conan: patch %s/CMakeLists.txt" %
                              self.ZIP_FOLDER_NAME)
-            # Note: prevent build of SHARED lib too! CK
-            tools.replace_in_file(
-                "CMakeLists.txt", 'add_library(zlib SHARED', 'add_library(zlib')
-            # Note: prevent use of win32/zlib1.rc under MSYS! CK
-            tools.replace_in_file(
-                "CMakeLists.txt", 'if(NOT MINGW)', 'if(MINGW)')
+            # Note: build either SHARED or STATIC zlib! CK
+            # prevent use of win32/zlib1.rc under MSYS too
+            tools.patch(patch_file="../CMakeLists.patch")
 
             files.mkdir("_build")
             with tools.chdir("_build"):

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,8 +55,9 @@ class ZlibConan(ConanFile):
                 else:
                     cmake.configure()
                 cmake.build()
-                if not tools.cross_building(self.settings):
-                    cmake.test()
+                # # TBD: may be added later? CK
+                # if not tools.cross_building(self.settings):
+                #     cmake.test()
                 cmake.install()
 
     def package(self):
@@ -74,10 +75,10 @@ class ZlibConan(ConanFile):
         # NOTE: other files are installed with cmake.install()
 
     def package_info(self):
-        if self.settings.os == "Windows":
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
             self.cpp_info.libs = ['zlib']
-            # TBD: IMHO unwanted with conan!
-            # if self.settings.build_type == "Debug" and self.settings.compiler == "Visual Studio":
-            #     self.cpp_info.libs[0] += "d"
+            # IMHO: unwanted with conan! CK
+            if self.settings.build_type == "Debug" and self.settings.compiler == "Visual Studio":
+                self.cpp_info.libs[0] += "d"
         else:
             self.cpp_info.libs = ['z']

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,8 +26,6 @@ class ZlibConan(ConanFile):
         tools.unzip(z_name)
         os.unlink(z_name)
         files.rmdir("%s/contrib" % self.ZIP_FOLDER_NAME)
-        # if self.settings.os != "Windows":
-        ### self.run("chmod +x ./%s/configure" % self.ZIP_FOLDER_NAME)
 
     def build(self):
         with tools.chdir(os.path.join(self.source_folder, self.ZIP_FOLDER_NAME)):
@@ -38,10 +36,10 @@ class ZlibConan(ConanFile):
                     definitions = {
                         "BUILD_SHARED_LIBS": "ON"
                     }
-                    cmake.configure(defs=definitions, build_dir=".")
+                    cmake.configure(defs=definitions)
                 else:
-                    cmake.configure(build_dir=".")
-                cmake.build(build_dir=".")
+                    cmake.configure()
+                cmake.build()
                 cmake.install()
 
     def package(self):
@@ -56,17 +54,13 @@ class ZlibConan(ConanFile):
         # Copy the license files
         self.copy("LICENSE", src=self.ZIP_FOLDER_NAME, dst=".")
 
-        # NOTE: done by cmake.install()
-        # Copy pc file
-        ### self.copy("*.pc", dst="", keep_path=False)
-        # Copying zlib.h, zutil.h, zconf.h
-        ### self.copy("*.h", "include", "%s" % self.ZIP_FOLDER_NAME, keep_path=False)
-        ### self.copy("*.h", "include", "%s" % "_build", keep_path=False)
+        # NOTE: other files are installed with cmake.install()
 
     def package_info(self):
         if self.settings.os == "Windows":
             self.cpp_info.libs = ['zlib']
-            if self.settings.build_type == "Debug" and self.settings.compiler == "Visual Studio":
-                self.cpp_info.libs[0] += "d"
+            # TBD: IMHO unwanted with conan!
+            # if self.settings.build_type == "Debug" and self.settings.compiler == "Visual Studio":
+            #     self.cpp_info.libs[0] += "d"
         else:
             self.cpp_info.libs = ['z']

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,34 +26,23 @@ class ZlibConan(ConanFile):
         tools.unzip(z_name)
         os.unlink(z_name)
         files.rmdir("%s/contrib" % self.ZIP_FOLDER_NAME)
-        if self.settings.os != "Windows":
-            self.run("chmod +x ./%s/configure" % self.ZIP_FOLDER_NAME)
+        # if self.settings.os != "Windows":
+        ### self.run("chmod +x ./%s/configure" % self.ZIP_FOLDER_NAME)
 
     def build(self):
         with tools.chdir(os.path.join(self.source_folder, self.ZIP_FOLDER_NAME)):
             files.mkdir("_build")
             with tools.chdir("_build"):
-                if not tools.os_info.is_windows:
-                    env_build = AutoToolsBuildEnvironment(self)
-                    if self.settings.arch in ["x86", "x86_64"] and self.settings.compiler in ["apple-clang", "clang", "gcc"]:
-                        env_build.flags.append('-mstackrealign')
-
-                    env_build.fpic = True
-
-                    if self.settings.os == "Macos":
-                        old_str = '-install_name $libdir/$SHAREDLIBM'
-                        new_str = '-install_name $SHAREDLIBM'
-                        tools.replace_in_file("../configure", old_str, new_str)
-
-                    if self.settings.os == "Windows":  # Cross building to Linux
-                        tools.replace_in_file("../configure", 'LDSHAREDLIBC="${LDSHAREDLIBC--lc}"', 'LDSHAREDLIBC=""')
-                    # Zlib configure doesnt allow this parameters
-                    env_build.configure("../", build=False, host=False, target=False)
-                    env_build.make()
+                cmake = CMake(self)
+                if self.options.shared:
+                    definitions = {
+                        "BUILD_SHARED_LIBS": "ON"
+                    }
+                    cmake.configure(defs=definitions, build_dir=".")
                 else:
-                    cmake = CMake(self)
                     cmake.configure(build_dir=".")
-                    cmake.build(build_dir=".")
+                cmake.build(build_dir=".")
+                cmake.install()
 
     def package(self):
         self.output.warn("local cache: %s" % self.in_local_cache)
@@ -67,48 +56,12 @@ class ZlibConan(ConanFile):
         # Copy the license files
         self.copy("LICENSE", src=self.ZIP_FOLDER_NAME, dst=".")
 
+        # NOTE: done by cmake.install()
         # Copy pc file
-        self.copy("*.pc", dst="", keep_path=False)
+        ### self.copy("*.pc", dst="", keep_path=False)
         # Copying zlib.h, zutil.h, zconf.h
-        self.copy("*.h", "include", "%s" % self.ZIP_FOLDER_NAME, keep_path=False)
-        self.copy("*.h", "include", "%s" % "_build", keep_path=False)
-
-        # Copying static and dynamic libs
-        build_dir = os.path.join(self.ZIP_FOLDER_NAME, "_build")
-        if self.settings.os == "Windows":
-            if self.options.shared:
-                build_dir = os.path.join(self.ZIP_FOLDER_NAME, "_build")
-                self.copy(pattern="*.dll", dst="bin", src=build_dir, keep_path=False)
-                build_dir = os.path.join(self.ZIP_FOLDER_NAME, "_build/lib")
-                self.copy(pattern="*zlibd.lib", dst="lib", src=build_dir, keep_path=False)
-                self.copy(pattern="*zlib.lib", dst="lib", src=build_dir, keep_path=False)
-                self.copy(pattern="*zlib.dll.a", dst="lib", src=build_dir, keep_path=False)
-            else:
-                build_dir = os.path.join(self.ZIP_FOLDER_NAME, "_build/lib")
-                if self.settings.os == "Windows":
-                    # MinGW
-                    self.copy(pattern="libzlibstaticd.a", dst="lib", src=build_dir, keep_path=False)
-                    self.copy(pattern="libzlibstatic.a", dst="lib", src=build_dir, keep_path=False)
-                    # Visual Studio
-                    self.copy(pattern="zlibstaticd.lib", dst="lib", src=build_dir, keep_path=False)
-                    self.copy(pattern="zlibstatic.lib", dst="lib", src=build_dir, keep_path=False)
-
-                lib_path = os.path.join(self.package_folder, "lib")
-                suffix = "d" if self.settings.build_type == "Debug" else ""
-                if self.settings.compiler == "Visual Studio":
-                    current_lib = os.path.join(lib_path, "zlibstatic%s.lib" % suffix)
-                    os.rename(current_lib, os.path.join(lib_path, "zlib%s.lib" % suffix))
-                elif self.settings.compiler == "gcc":
-                    current_lib = os.path.join(lib_path, "libzlibstatic.a")
-                    os.rename(current_lib, os.path.join(lib_path, "libzlib.a"))
-        else:
-            if self.options.shared:
-                if self.settings.os == "Macos":
-                    self.copy(pattern="*.dylib", dst="lib", src=build_dir, keep_path=False)
-                else:
-                    self.copy(pattern="*.so*", dst="lib", src=build_dir, keep_path=False)
-            else:
-                self.copy(pattern="*.a", dst="lib", src=build_dir, keep_path=False)
+        ### self.copy("*.h", "include", "%s" % self.ZIP_FOLDER_NAME, keep_path=False)
+        ### self.copy("*.h", "include", "%s" % "_build", keep_path=False)
 
     def package_info(self):
         if self.settings.os == "Windows":

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,16 +2,7 @@ cmake_minimum_required(VERSION 3.1.2)
 project(TestPackage C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-# conan is a buggy, prevent find_library() errors on MSYS! CK
-# -- Conan: Compiler GCC>=5, checking major version 6.4
-# -- Conan: Checking correct version: 6.4
-# -- Conan: Using cmake targets configuration
-# -- Library zlib not found in package, might be system one
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    conan_basic_setup()
-else()
-    conan_basic_setup(TARGETS)
-endif()
+conan_basic_setup(TARGETS)
 
 add_executable(enough enough.c)
 conan_target_link_libraries(enough)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,7 +2,16 @@ cmake_minimum_required(VERSION 3.1.2)
 project(TestPackage C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+# conan is a buggy, prevent find_library() errors on MSYS! CK
+# -- Conan: Compiler GCC>=5, checking major version 6.4
+# -- Conan: Checking correct version: 6.4
+# -- Conan: Using cmake targets configuration
+# -- Library zlib not found in package, might be system one
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    conan_basic_setup()
+else()
+    conan_basic_setup(TARGETS)
+endif()
 
 add_executable(enough enough.c)
 conan_target_link_libraries(enough)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-PROJECT(MyHello)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.2)
+project(TestPackage C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-CONAN_BASIC_SETUP(TARGETS)
+conan_basic_setup(TARGETS)
 
 add_executable(enough enough.c)
-target_link_libraries(enough CONAN_PKG::zlib)
+conan_target_link_libraries(enough)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,6 +1,7 @@
 from conans.model.conan_file import ConanFile, tools
 from conans import CMake
-import os, platform
+import os
+import platform
 
 
 class DefaultNameConan(ConanFile):
@@ -10,18 +11,15 @@ class DefaultNameConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        # Compatibility with Conan < 1.0 (#2234)
-        generator = "Unix Makefiles" if platform.system() != "Windows" else None 
-        cmake = CMake(self, generator=generator)
+        cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def imports(self):
         self.copy(pattern="*.dll", dst="bin", src="bin")
         self.copy(pattern="*.dylib", dst="bin", src="lib")
-        
+
     def test(self):
         if not tools.cross_building(self.settings):
             self.run("cd bin && .%senough" % os.sep)
         assert os.path.exists(os.path.join(self.deps_cpp_info["zlib"].rootpath, "LICENSE"))
-


### PR DESCRIPTION
Use always cmake to build and install.
autopep8 *.py files.
Prevent use of debug suffix under Windows.