### PR TITLE
- more correct check for compiler definition

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -34,10 +34,10 @@ class ZlibConan(ConanFile):
             for filename in ['zconf.h', 'zconf.h.cmakein', 'zconf.h.in']:
                 tools.replace_in_file(filename,
                                       '#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */',
-                                      '#if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H != 0')
+                                      '#if defined(HAVE_UNISTD_H) && (1-HAVE_UNISTD_H-1 != 0)')
                 tools.replace_in_file(filename,
                                       '#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */',
-                                      '#if defined(HAVE_STDARG_H) && HAVE_STDARG_H != 0')
+                                      '#if defined(HAVE_STDARG_H) && (1-HAVE_STDARG_H-1 != 0)')
             files.mkdir("_build")
             with tools.chdir("_build"):
                 if not tools.os_info.is_windows:


### PR DESCRIPTION
follow up on https://github.com/conan-community/conan-zlib/pull/41
fixed libxml2 build problem discovered on https://github.com/bincrafters/conan-libxml2/pull/6
check for HAVE_UNISTD_H/HAVE_STDARG_H is now more strict to handle empty macro values:
```
(1-HAVE_STDARG_H-1 != 0)
```
if we have `#define HAVE_STDARG_H 1`, expression evaluates to `(1 - 1 - 1 != 0) -> (-1 != 0) -> true`
if we have `#define HAVE_STDARG_H` (empty), expression evaluates to `(1 - -1 != 0) -> (2 != 0) -> true`
if we have `#define HAVE_STDARG_H 0`, expression evaluates to `(1 - 0 - 1 != 0) -> (0 != 0) -> false`
