### PR TITLE
Added a missing include so zlib may be compiled for iOS on ARM64 arch

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -55,6 +55,10 @@ class ZlibConan(ConanFile):
                     if self.settings.os == "Windows":  # Cross building to Linux
                         tools.replace_in_file("../configure", 'LDSHAREDLIBC="${LDSHAREDLIBC--lc}"', 'LDSHAREDLIBC=""')
                     # Zlib configure doesnt allow this parameters
+
+                    if self.settings.os == "iOS":
+                        tools.replace_in_file("../gzguts.h", '#ifdef _LARGEFILE64_SOURCE', '#include <unistd.h>\n\n#ifdef _LARGEFILE64_SOURCE')
+
                     if self.settings.os == "Windows" and tools.os_info.is_linux:
                         # Let our profile to declare what is needed.
                         tools.replace_in_file("../win32/Makefile.gcc", 'LDFLAGS = $(LOC)', '')


### PR DESCRIPTION
The conan recipe for zlib fails on iOS/arm64. Applied a missing include, as also described here

https://stackoverflow.com/questions/22227029/how-to-build-zlib-for-arm64

which makes it compile again.

