### PR TITLE
Use system ranlib instead of GNU ranlib

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -77,9 +77,9 @@ class ZlibConan(ConanFile):
                     tools.replace_in_file("../Makefile.in", "$(CC) $(CFLAGS) -o", "$(CC) $(LDFLAGS) -o")
 
                     env_build_vars = env_build.vars
-                    if self.settings.os == "Macos":
+                    if tools.is_apple_os(self.settings.os):
                         # force macOS ranlib because ranlib from binutils produced malformed ar archives
-                        env_build_vars['RANLIB'] = '/usr/bin/ranlib'
+                        env_build_vars['RANLIB'] = tools.XCRun(self.settings).ranlib
 
                     if self.settings.os == "Windows" and tools.os_info.is_linux:
                         # we need to build only libraries without test example and minigzip

--- a/conanfile.py
+++ b/conanfile.py
@@ -76,6 +76,11 @@ class ZlibConan(ConanFile):
                     # same thing in Makefile.in, when building tests/example executables
                     tools.replace_in_file("../Makefile.in", "$(CC) $(CFLAGS) -o", "$(CC) $(LDFLAGS) -o")
 
+                    env_build_vars = env_build.vars
+                    if self.settings.os == "Macos":
+                        # force macOS ranlib because ranlib from binutils produced malformed ar archives
+                        env_build_vars['RANLIB'] = '/usr/bin/ranlib'
+
                     if self.settings.os == "Windows" and tools.os_info.is_linux:
                         # we need to build only libraries without test example and minigzip
                         if self.options.shared:
@@ -98,8 +103,8 @@ class ZlibConan(ConanFile):
                                 make_target = "libz.so.%s" % self.version
                         else:
                             make_target = "libz.a"
-                        env_build.configure("../", build=False, host=False, target=False)
-                        env_build.make(target=make_target)
+                        env_build.configure("../", build=False, host=False, target=False, vars=env_build_vars)
+                        env_build.make()
                 else:
                     cmake = CMake(self)
                     cmake.configure(build_dir=".")

--- a/conanfile.py
+++ b/conanfile.py
@@ -104,7 +104,7 @@ class ZlibConan(ConanFile):
                         else:
                             make_target = "libz.a"
                         env_build.configure("../", build=False, host=False, target=False, vars=env_build_vars)
-                        env_build.make()
+                        env_build.make(target=make_target)
                 else:
                     cmake = CMake(self)
                     cmake.configure(build_dir=".")


### PR DESCRIPTION
Fixes conan-community/community#111

Providing environment variable RANLIB allows `configure` script to locate a system ranlib.