### PR TITLE
Fixed minizip build on Debug mode on windows

### DIFF
--- a/CMakeLists_minizip.txt
+++ b/CMakeLists_minizip.txt
@@ -22,7 +22,7 @@ target_include_directories(minizip PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../../_build
   ${CMAKE_CURRENT_SOURCE_DIR}/../../_build/source_subfolder)
 
-find_library(ZLIB_LIBRARY NAMES z zlib zlibstatic zlibstaticd PATHS
+find_library(ZLIB_LIBRARY NAMES z zlib zlibd zlibstatic zlibstaticd PATHS
   ${CMAKE_CURRENT_SOURCE_DIR}/../../_build
   ${CMAKE_CURRENT_SOURCE_DIR}/../../_build/lib)
 


### PR DESCRIPTION
Fixes the following CMake error when trying to build with minizip in Debug mode on Windows : 

`CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
ZLIB_LIBRARY
    linked by target "minizip" in directory C:/Users/name/.conan/data/zlib/1.2.11/conan/stable/build/3d6191458ea09d32873796a1620621d06a5ba93c/source_subfolder/contrib/minizip`