### PR TITLE
Fix test_package when using minizip=True

### DIFF
--- a/FindZLIB.cmake
+++ b/FindZLIB.cmake
@@ -3,11 +3,14 @@ if(ZLIB_FOUND)
 endif()
 
 find_path(ZLIB_INCLUDE_DIR NAMES zlib.h PATHS ${CONAN_INCLUDE_DIRS_ZLIB})
-find_library(ZLIB_LIBRARY NAMES ${CONAN_LIBS_ZLIB} PATHS ${CONAN_LIB_DIRS_ZLIB})
+
+foreach(conan_lib_zlib ${CONAN_LIBS_ZLIB})
+  find_library(ZLIB_LIB_${conan_lib_zlib} NAMES ${conan_lib_zlib} PATHS ${CONAN_LIB_DIRS_ZLIB})
+  list(APPEND ZLIB_LIBRARIES ${ZLIB_LIB_${conan_lib_zlib}})
+endforeach()
 
 set(ZLIB_FOUND TRUE)
 set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
-set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
 mark_as_advanced(ZLIB_LIBRARIES ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
 
 if (NOT TARGET ZLIB::ZLIB)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,15 +2,13 @@ cmake_minimum_required(VERSION 3.0)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
-find_package(ZLIB REQUIRED)
+conan_basic_setup(TARGETS)
 
 add_executable(test_zlib test.c)
-target_link_libraries(test_zlib ZLIB::ZLIB)
+target_link_libraries(test_zlib CONAN_PKG::zlib)
 set_target_properties(test_zlib PROPERTIES OUTPUT_NAME "test")
 
 if(WITH_MINIZIP)
   add_executable(test_minizip test_minizip.c)
-  target_link_libraries(test_minizip ZLIB::ZLIB)
+  target_link_libraries(test_minizip CONAN_PKG::zlib)
 endif()

--- a/test_package/test_minizip.c
+++ b/test_package/test_minizip.c
@@ -9,7 +9,7 @@
 #endif
 
 /* TODO: create test for this headers */
-#include <crypt.h>
+// #include <crypt.h>
 #include <mztools.h>
 
 const char text[] = ""
@@ -238,7 +238,7 @@ void Display64BitsSize(ZPOS64_T n, int size_char) {
     int offset = 19;
     int pos_string = 19;
     number[20] = 0;
-    
+
     for (;;) {
         number[offset] = (char) ((n % 10) + '0');
       if (number[offset] != '0') {


### PR DESCRIPTION
FYI @SSE4 

I started by fixing the `FindZLIB.cmake` to correctly locate all individual libraries, then @SSE4 suggested it was probably not needed, so instead I changed the `test/CMakeLists.txt`, but kept the updated `FindZLIB.cmake` (might be needed for other projects that depends on it)